### PR TITLE
Fix `Renamed.ini` to avoid NPE during loading

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -9,13 +9,17 @@
     <!-- types are add, fix, remove, update -->
     <release version="2.1.2" date="SNAPSHOT" description="Version 2.1.2">
       <action dev="jodastephen" type="fix">
+        Fix `Renamed.ini` to avoid NPE during loading.
+        A null `RenameHandler.INSTANCE` could be observed if `Renamed.ini` referred to a class
+        with a static initializer that referred back to `RenameHandler`.
+      </action>
+      <action dev="jodastephen" type="fix">
         Fix build to work on Java 11.
       </action>
     </release>
     <release version="2.1.1" date="2018-07-10" description="Version 2.1.1">
       <action dev="jodastephen" type="add">
         Log startup issues when using renames by configuration.
-        Add `Renamed.ini` to configure renames more cleanly.
       </action>
     </release>
     <release version="2.1" date="2018-06-08" description="Version 2.1">

--- a/src/main/java/org/joda/convert/RenameHandler.java
+++ b/src/main/java/org/joda/convert/RenameHandler.java
@@ -63,13 +63,14 @@ public final class RenameHandler {
      * This is a singleton instance which is mutated.
      * It will be populated by the contents of the {@code Renamed.ini} configuration files.
      */
-    public static final RenameHandler INSTANCE;
+    public static final RenameHandler INSTANCE = create(false);
     static {
         // log errors to System.err, as problems in static initializers can be troublesome to diagnose
-        RenameHandler handler = new RenameHandler();
         try {
-            // don't just call loadFromClasspath() as that mutates and might leave an invalid state
-            handler = create(true);
+            // calling loadFromClasspath() is the best option even though it mutates INSTANCE
+            // only serious errors will be caught here, most errors will log from parseRenameFile()
+            INSTANCE.loadFromClasspath();
+
         } catch (IllegalStateException ex) {
             System.err.println("ERROR: " + ex.getMessage());
             ex.printStackTrace();
@@ -80,7 +81,6 @@ public final class RenameHandler {
             System.err.println("ERROR: Failed to load Renamed.ini files: " + ex.getMessage());
             ex.printStackTrace();
         }
-        INSTANCE = handler;
     }
 
     /**

--- a/src/test/java/org/joda/convert/TestRenameHandler.java
+++ b/src/test/java/org/joda/convert/TestRenameHandler.java
@@ -16,10 +16,12 @@
 package org.joda.convert;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
 
@@ -27,6 +29,8 @@ import org.junit.Test;
  * Test {@link RenameHandler}.
  */
 public class TestRenameHandler {
+
+    static final AtomicBoolean BAD_INIT = new AtomicBoolean();
 
     @Test
     public void test_matchRenamedType() throws ClassNotFoundException {
@@ -84,6 +88,9 @@ public class TestRenameHandler {
             String logged = baos.toString("UTF-8");
             assertTrue(logged.startsWith("ERROR: Invalid Renamed.ini: "));
             assertTrue(logged.contains("org.joda.convert.ClassDoesNotExist"));
+            // ensure that the bad init class is loaded, and that it did not see a null RenameHandler
+            assertTrue(test.getTypeRenames().containsKey("com.foo.convert.TestRenameHandlerBadInit"));
+            assertFalse(BAD_INIT.get());
 
         } finally {
             System.setErr(originalErr);

--- a/src/test/java/org/joda/convert/TestRenameHandlerBadInit.java
+++ b/src/test/java/org/joda/convert/TestRenameHandlerBadInit.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2010-present Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.joda.convert;
+
+/**
+ * A class that spots bad initialization.
+ */
+public class TestRenameHandlerBadInit {
+
+    static {
+        if (RenameHandler.INSTANCE == null) {
+            TestRenameHandler.BAD_INIT.set(true);
+        }
+    }
+
+}

--- a/src/test/resources/META-INF/org/joda/convert/Renamed.ini
+++ b/src/test/resources/META-INF/org/joda/convert/Renamed.ini
@@ -3,6 +3,7 @@
 com.foo.Bar = org.joda.convert.Status
 # this class does not exist and an error will be printed when running the tests
 com.foo.Bar = org.joda.convert.ClassDoesNotExist
+com.foo.convert.TestRenameHandlerBadInit = org.joda.convert.TestRenameHandlerBadInit
 
 # Test renamed enums
 [enums]


### PR DESCRIPTION
A null `RenameHandler.INSTANCE` could be observed if `Renamed.ini` referred to a class with a static initializer that referred back to `RenameHandler`