### PR TITLE
Update deployment from OSSRH

### DIFF
--- a/.github/maven-settings.xml
+++ b/.github/maven-settings.xml
@@ -4,9 +4,9 @@
                           https://maven.apache.org/xsd/settings-1.0.0.xsd">
   <servers>
     <server>
-      <id>sonatype-joda-staging</id>
-      <username>${env.OSSRH_USERNAME}</username>
-      <password>${env.OSSRH_TOKEN}</password>
+      <id>central</id>
+      <username>${env.MAVEN_CENTRAL_USERNAME}</username>
+      <password>${env.MAVEN_CENTRAL_PASSWORD}</password>
     </server>
     <server>
       <id>github</id>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,8 +50,8 @@ jobs:
 
     - name: Maven release
       env:
-        OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-        OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+        MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+        MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.RELEASES_GPG_PASSPHRASE }}
         MAVEN_GPG_KEY: ${{ secrets.RELEASES_GPG_PRIVATE_KEY }}
         GITHUB_TOKEN: ${{ secrets.PERSONAL_GITHUB_TOKEN }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -16,6 +16,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+        ref: ${{ github.ref }}
         fetch-tags: true
 
     - name: Setup git
@@ -70,6 +71,7 @@ jobs:
         git push origin main
 
     - name: Delete website tag
+      if: "always()"
       run: |
         git tag --delete "${GITHUB_REF_NAME}" || true
         git push --delete origin "${GITHUB_REF_NAME}" || true

--- a/README.md
+++ b/README.md
@@ -101,5 +101,5 @@ Tidelift will coordinate the fix and disclosure.
 
 Release from local:
 
-* Turn off gpg "bc" signer
+* Ensure `gpg-agent` is running
 * `mvn clean release:clean release:prepare release:perform`

--- a/pom.xml
+++ b/pom.xml
@@ -592,25 +592,20 @@
   </reporting>
 
   <!-- ==================================================================== -->
-  <distributionManagement>
-    <repository>
-      <id>sonatype-joda-staging</id>
-      <name>Sonatype OSS staging repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-      <layout>default</layout>
-    </repository>
-    <snapshotRepository>
-      <uniqueVersion>false</uniqueVersion>
-      <id>sonatype-joda-snapshot</id>
-      <name>Sonatype OSS snapshot repository</name>
-      <url>https://oss.sonatype.org/content/repositories/joda-snapshots</url>
-      <layout>default</layout>
-    </snapshotRepository>
-    <downloadUrl>https://oss.sonatype.org/content/repositories/joda-releases</downloadUrl>
-  </distributionManagement>
-
-  <!-- ==================================================================== -->
   <profiles>
+    <!-- Set environment when running on GitHub Actions -->
+    <profile>
+      <id>github-action</id>
+      <activation>
+        <property>
+          <name>env.GITHUB_ACTIONS</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <properties>
+        <gpg.signer>bc</gpg.signer>
+      </properties>
+    </profile>
     <!-- Main deployment profile, activated by -Doss.repo -->
     <profile>
       <id>release-artifacts</id>
@@ -653,24 +648,20 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
-                <configuration>
-                  <signer>bc</signer>
-                </configuration>
               </execution>
             </executions>
           </plugin>
-          <!-- Use nexus plugin to directly release -->
+          <!-- Use central plugin to directly release -->
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${central-publishing-maven-plugin.version}</version>
             <extensions>true</extensions>
             <configuration>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <serverId>sonatype-joda-staging</serverId>
-              <autoReleaseAfterClose>${joda.nexus.auto.release}</autoReleaseAfterClose>
-              <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
-              <stagingProgressTimeoutMinutes>20</stagingProgressTimeoutMinutes>
+              <publishingServerId>central</publishingServerId>
+              <deploymentName>${project.name}</deploymentName>
+              <autoPublish>${joda.publish.auto}</autoPublish>
+              <waitUntil>${joda.publish.wait}</waitUntil>
             </configuration>
           </plugin>
           <!-- Release dist files to GitHub -->
@@ -721,7 +712,8 @@
     <!-- Common control parameters -->
     <joda.osgi.packages>org.joda.convert.*</joda.osgi.packages>
     <joda.osgi.require.capability>osgi.ee;filter:="(&amp;(osgi.ee=JavaSE)(version=${maven.compiler.release}))"</joda.osgi.require.capability>
-    <joda.nexus.auto.release>true</joda.nexus.auto.release>
+    <joda.publish.auto>true</joda.publish.auto><!-- false/true -->
+    <joda.publish.wait>published</joda.publish.wait><!-- validated/published -->
 
     <!-- Plugin version numbers -->
     <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
@@ -749,10 +741,10 @@
     <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
     <maven-surefire-report-plugin.version>3.5.2</maven-surefire-report-plugin.version>
     <maven-toolchains-plugin.version>3.2.0</maven-toolchains-plugin.version>
+    <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
     <github-api.version>1.326</github-api.version>
     <github-release-plugin.version>1.6.0</github-release-plugin.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
-    <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
     <revapi-maven-plugin.version>0.11.1</revapi-maven-plugin.version>
     <revapi-java.version>0.15.1</revapi-java.version>
     <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>


### PR DESCRIPTION
OSSRH is dead, use replacement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Maven and GitHub Actions configurations to use new environment variable names for publishing to Maven Central.
  * Replaced the Maven plugin for artifact publishing with a new plugin and updated related settings.
  * Improved release workflow reliability by ensuring tag deletion always runs and explicit branch/tag checkout.
  * Updated README instructions for local releases to clarify GPG agent requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->